### PR TITLE
Fixed the bug by converting the storedTokenExpiry to milliseconds

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,20 +26,11 @@ const App = () => {
     document.title = "imposter.ai";
   }, []);
 
-  // useEffect(() => {
-  //   const link = document.querySelector("link[rel*='icon']") || document.createElement('link');
-  //   link.type = 'image/x-icon';
-  //   link.rel = 'shortcut icon';
-  //   link.href = '%PUBLIC_URL%/favicon.ico';
-
-  //   document.getElementsByTagName('head')[0].appendChild(link);
-  // }, []);
-
   // This effect runs once when the component mounts
   useEffect(() => {
     // Check if a user token is stored in local storage
     const storedToken = localStorage.getItem('token');
-    const storedTokenExpiry = localStorage.getItem('tokenExpiry');
+    const storedTokenExpiry = Number(localStorage.getItem('tokenExpiry')) * 1000; // Convert to milliseconds
 
     // If the stored token exists and it hasn't expired, set it as the current token state
     if (storedToken && new Date().getTime() < storedTokenExpiry) {


### PR DESCRIPTION
When comparing the Token Expiration time to the time right now, The now time was in milliseconds and the expiration time was in seconds so the now time always seemed larger than the now time making the frontend think the token was expired. 
